### PR TITLE
Updated number formats used in characteristics and fixed compatibility with newer HS110 revisions

### DIFF
--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -1,99 +1,99 @@
 const inherits = require('util').inherits;
 
 module.exports = function (homebridge) {
-  const Characteristic = homebridge.hap.Characteristic;
+    const Characteristic = homebridge.hap.Characteristic;
 
-  const CustomCharacteristic = {};
+    const CustomCharacteristic = {};
 
-  CustomCharacteristic.Volts = function () {
-    Characteristic.call(this, 'Volts', CustomCharacteristic.Volts.UUID);
-    this.setProps({
-      format: Characteristic.Formats.FLOAT,
-      unit: 'V',
-      minValue: 0,
-      maxValue: 65535,
-      minStep: 0.1,
-      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-    });
-    this.value = this.getDefaultValue();
-  };
-  CustomCharacteristic.Volts.UUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52';
-  inherits(CustomCharacteristic.Volts, Characteristic);
+    CustomCharacteristic.Volts = function () {
+        Characteristic.call(this, 'Volts', CustomCharacteristic.Volts.UUID);
+        this.setProps({
+                      format: Characteristic.Formats.FLOAT,
+                      unit: 'V',
+                      minValue: 0,
+                      maxValue: 65535,
+                      minStep: 0.1,
+                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+                      });
+        this.value = this.getDefaultValue();
+    };
+    CustomCharacteristic.Volts.UUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52';
+    inherits(CustomCharacteristic.Volts, Characteristic);
 
-  CustomCharacteristic.Amperes = function () {
-    Characteristic.call(this, 'Amps', CustomCharacteristic.Amperes.UUID);
-    this.setProps({
-      format: Characteristic.Formats.FLOAT,
-      unit: 'A',
-      minValue: 0,
-      maxValue: 65535,
-      minStep: 0.01,
-      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-    });
-    this.value = this.getDefaultValue();
-  };
-  CustomCharacteristic.Amperes.UUID = 'E863F126-079E-48FF-8F27-9C2605A29F52';
-  inherits(CustomCharacteristic.Amperes, Characteristic);
+    CustomCharacteristic.Amperes = function () {
+        Characteristic.call(this, 'Amps', CustomCharacteristic.Amperes.UUID);
+        this.setProps({
+                      format: Characteristic.Formats.FLOAT,
+                      unit: 'A',
+                      minValue: 0,
+                      maxValue: 65535,
+                      minStep: 0.01,
+                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+                      });
+        this.value = this.getDefaultValue();
+    };
+    CustomCharacteristic.Amperes.UUID = 'E863F126-079E-48FF-8F27-9C2605A29F52';
+    inherits(CustomCharacteristic.Amperes, Characteristic);
 
-  CustomCharacteristic.Watts = function () {
-    Characteristic.call(this, 'Consumption', CustomCharacteristic.Watts.UUID);
-    this.setProps({
-      format: Characteristic.Formats.FLOAT,
-      unit: 'W',
-      minValue: 0,
-      maxValue: 65535,
-      minStep: 0.1,
-      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-    });
-    this.value = this.getDefaultValue();
-  };
-  CustomCharacteristic.Watts.UUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
-  inherits(CustomCharacteristic.Watts, Characteristic);
+    CustomCharacteristic.Watts = function () {
+        Characteristic.call(this, 'Consumption', CustomCharacteristic.Watts.UUID);
+        this.setProps({
+                      format: Characteristic.Formats.FLOAT,
+                      unit: 'W',
+                      minValue: 0,
+                      maxValue: 65535,
+                      minStep: 0.1,
+                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+                      });
+        this.value = this.getDefaultValue();
+    };
+    CustomCharacteristic.Watts.UUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
+    inherits(CustomCharacteristic.Watts, Characteristic);
 
-  CustomCharacteristic.VoltAmperes = function () {
-    Characteristic.call(this, 'Apparent Power', CustomCharacteristic.VoltAmperes.UUID);
-    this.setProps({
-      format: Characteristic.Formats.UINT16,
-      unit: 'VA',
-      minValue: 0,
-      maxValue: 65535,
-      minStep: 1,
-      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-    });
-    this.value = this.getDefaultValue();
-  };
-  CustomCharacteristic.VoltAmperes.UUID = 'E863F110-079E-48FF-8F27-9C2605A29F52';
-  inherits(CustomCharacteristic.VoltAmperes, Characteristic);
+    CustomCharacteristic.VoltAmperes = function () {
+        Characteristic.call(this, 'Apparent Power', CustomCharacteristic.VoltAmperes.UUID);
+        this.setProps({
+                      format: Characteristic.Formats.UINT16,
+                      unit: 'VA',
+                      minValue: 0,
+                      maxValue: 65535,
+                      minStep: 1,
+                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+                      });
+        this.value = this.getDefaultValue();
+    };
+    CustomCharacteristic.VoltAmperes.UUID = 'E863F110-079E-48FF-8F27-9C2605A29F52';
+    inherits(CustomCharacteristic.VoltAmperes, Characteristic);
 
-  CustomCharacteristic.KilowattHours = function () {
-    Characteristic.call(this, 'Total Consumption', CustomCharacteristic.KilowattHours.UUID);
-    this.setProps({
-      format: Characteristic.Formats.FLOAT,
-      unit: 'kWh',
-      minValue: 0,
-      maxValue: 65535,
-      minStep: 0.001,
-      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-    });
-    this.value = this.getDefaultValue();
-  };
-  CustomCharacteristic.KilowattHours.UUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
-  inherits(CustomCharacteristic.KilowattHours, Characteristic);
+    CustomCharacteristic.KilowattHours = function () {
+        Characteristic.call(this, 'Total Consumption', CustomCharacteristic.KilowattHours.UUID);
+        this.setProps({
+                      format: Characteristic.Formats.FLOAT,
+                      unit: 'kWh',
+                      minValue: 0,
+                      maxValue: 65535,
+                      minStep: 0.001,
+                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+                      });
+        this.value = this.getDefaultValue();
+    };
+    CustomCharacteristic.KilowattHours.UUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
+    inherits(CustomCharacteristic.KilowattHours, Characteristic);
+    
+    CustomCharacteristic.KilowattVoltAmpereHour = function () {
+        Characteristic.call(this, 'Apparent Energy', CustomCharacteristic.KilowattVoltAmpereHour.UUID);
+        this.setProps({
+                      format: Characteristic.Formats.UINT32,
+                      unit: 'kVAh',
+                      minValue: 0,
+                      maxValue: 65535,
+                      minStep: 1,
+                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+                      });
+        this.value = this.getDefaultValue();
+    };
+    CustomCharacteristic.KilowattVoltAmpereHour.UUID = 'E863F127-079E-48FF-8F27-9C2605A29F52';
+    inherits(CustomCharacteristic.KilowattVoltAmpereHour, Characteristic);
 
-  CustomCharacteristic.KilowattVoltAmpereHour = function () {
-    Characteristic.call(this, 'Apparent Energy', CustomCharacteristic.KilowattVoltAmpereHour.UUID);
-    this.setProps({
-      format: Characteristic.Formats.UINT32,
-      unit: 'kVAh',
-      minValue: 0,
-      maxValue: 65535,
-      minStep: 1,
-      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-    });
-    this.value = this.getDefaultValue();
-  };
-  CustomCharacteristic.KilowattVoltAmpereHour.UUID = 'E863F127-079E-48FF-8F27-9C2605A29F52';
-  inherits(CustomCharacteristic.KilowattVoltAmpereHour, Characteristic);
-
-  return {CustomCharacteristic};
+    return {CustomCharacteristic};
 };

--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -8,11 +8,11 @@ module.exports = function (homebridge) {
   CustomCharacteristic.Volts = function () {
     Characteristic.call(this, 'Volts', CustomCharacteristic.Volts.UUID);
     this.setProps({
-      format: Characteristic.Formats.UINT16,
+      format: Characteristic.Formats.FLOAT,
       unit: 'V',
       minValue: 0,
       maxValue: 65535,
-      minStep: 1,
+      minStep: 0.1,
       perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
     });
     this.value = this.getDefaultValue();
@@ -23,11 +23,11 @@ module.exports = function (homebridge) {
   CustomCharacteristic.Amperes = function () {
     Characteristic.call(this, 'Amps', CustomCharacteristic.Amperes.UUID);
     this.setProps({
-      format: Characteristic.Formats.UINT16,
+      format: Characteristic.Formats.FLOAT,
       unit: 'A',
       minValue: 0,
       maxValue: 65535,
-      minStep: 1,
+      minStep: 0.01,
       perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
     });
     this.value = this.getDefaultValue();
@@ -38,11 +38,11 @@ module.exports = function (homebridge) {
   CustomCharacteristic.Watts = function () {
     Characteristic.call(this, 'Consumption', CustomCharacteristic.Watts.UUID);
     this.setProps({
-      format: Characteristic.Formats.UINT16,
+      format: Characteristic.Formats.FLOAT,
       unit: 'W',
       minValue: 0,
       maxValue: 65535,
-      minStep: 1,
+      minStep: 0.1,
       perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
     });
     this.value = this.getDefaultValue();
@@ -68,11 +68,11 @@ module.exports = function (homebridge) {
   CustomCharacteristic.KilowattHours = function () {
     Characteristic.call(this, 'Total Consumption', CustomCharacteristic.KilowattHours.UUID);
     this.setProps({
-      format: Characteristic.Formats.UINT32,
+      format: Characteristic.Formats.FLOAT,
       unit: 'kWh',
       minValue: 0,
       maxValue: 65535,
-      minStep: 1,
+      minStep: 0.001,
       perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
     });
     this.value = this.getDefaultValue();

--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -1,99 +1,99 @@
 const inherits = require('util').inherits;
 
 module.exports = function (homebridge) {
-    const Characteristic = homebridge.hap.Characteristic;
+  const Characteristic = homebridge.hap.Characteristic;
 
-    const CustomCharacteristic = {};
+  const CustomCharacteristic = {};
 
-    CustomCharacteristic.Volts = function () {
-        Characteristic.call(this, 'Volts', CustomCharacteristic.Volts.UUID);
-        this.setProps({
-                      format: Characteristic.Formats.FLOAT,
-                      unit: 'V',
-                      minValue: 0,
-                      maxValue: 65535,
-                      minStep: 0.1,
-                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-                      });
-        this.value = this.getDefaultValue();
-    };
-    CustomCharacteristic.Volts.UUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52';
-    inherits(CustomCharacteristic.Volts, Characteristic);
+  CustomCharacteristic.Volts = function () {
+    Characteristic.call(this, 'Volts', CustomCharacteristic.Volts.UUID);
+    this.setProps({
+      format: Characteristic.Formats.FLOAT,
+      unit: 'V',
+      minValue: 0,
+      maxValue: 65535,
+      minStep: 0.1,
+      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+    });
+    this.value = this.getDefaultValue();
+  };
+  CustomCharacteristic.Volts.UUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52';
+  inherits(CustomCharacteristic.Volts, Characteristic);
 
-    CustomCharacteristic.Amperes = function () {
-        Characteristic.call(this, 'Amps', CustomCharacteristic.Amperes.UUID);
-        this.setProps({
-                      format: Characteristic.Formats.FLOAT,
-                      unit: 'A',
-                      minValue: 0,
-                      maxValue: 65535,
-                      minStep: 0.01,
-                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-                      });
-        this.value = this.getDefaultValue();
-    };
-    CustomCharacteristic.Amperes.UUID = 'E863F126-079E-48FF-8F27-9C2605A29F52';
-    inherits(CustomCharacteristic.Amperes, Characteristic);
+  CustomCharacteristic.Amperes = function () {
+    Characteristic.call(this, 'Amps', CustomCharacteristic.Amperes.UUID);
+    this.setProps({
+      format: Characteristic.Formats.FLOAT,
+      unit: 'A',
+      minValue: 0,
+      maxValue: 65535,
+      minStep: 0.01,
+      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+    });
+    this.value = this.getDefaultValue();
+  };
+  CustomCharacteristic.Amperes.UUID = 'E863F126-079E-48FF-8F27-9C2605A29F52';
+  inherits(CustomCharacteristic.Amperes, Characteristic);
 
-    CustomCharacteristic.Watts = function () {
-        Characteristic.call(this, 'Consumption', CustomCharacteristic.Watts.UUID);
-        this.setProps({
-                      format: Characteristic.Formats.FLOAT,
-                      unit: 'W',
-                      minValue: 0,
-                      maxValue: 65535,
-                      minStep: 0.1,
-                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-                      });
-        this.value = this.getDefaultValue();
-    };
-    CustomCharacteristic.Watts.UUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
-    inherits(CustomCharacteristic.Watts, Characteristic);
+  CustomCharacteristic.Watts = function () {
+    Characteristic.call(this, 'Consumption', CustomCharacteristic.Watts.UUID);
+    this.setProps({
+      format: Characteristic.Formats.FLOAT,
+      unit: 'W',
+      minValue: 0,
+      maxValue: 65535,
+      minStep: 0.1,
+      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+    });
+    this.value = this.getDefaultValue();
+  };
+  CustomCharacteristic.Watts.UUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
+  inherits(CustomCharacteristic.Watts, Characteristic);
 
-    CustomCharacteristic.VoltAmperes = function () {
-        Characteristic.call(this, 'Apparent Power', CustomCharacteristic.VoltAmperes.UUID);
-        this.setProps({
-                      format: Characteristic.Formats.UINT16,
-                      unit: 'VA',
-                      minValue: 0,
-                      maxValue: 65535,
-                      minStep: 1,
-                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-                      });
-        this.value = this.getDefaultValue();
-    };
-    CustomCharacteristic.VoltAmperes.UUID = 'E863F110-079E-48FF-8F27-9C2605A29F52';
-    inherits(CustomCharacteristic.VoltAmperes, Characteristic);
+  CustomCharacteristic.VoltAmperes = function () {
+    Characteristic.call(this, 'Apparent Power', CustomCharacteristic.VoltAmperes.UUID);
+    this.setProps({
+      format: Characteristic.Formats.UINT16,
+      unit: 'VA',
+      minValue: 0,
+      maxValue: 65535,
+      minStep: 1,
+      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+    });
+    this.value = this.getDefaultValue();
+  };
+  CustomCharacteristic.VoltAmperes.UUID = 'E863F110-079E-48FF-8F27-9C2605A29F52';
+  inherits(CustomCharacteristic.VoltAmperes, Characteristic);
 
-    CustomCharacteristic.KilowattHours = function () {
-        Characteristic.call(this, 'Total Consumption', CustomCharacteristic.KilowattHours.UUID);
-        this.setProps({
-                      format: Characteristic.Formats.FLOAT,
-                      unit: 'kWh',
-                      minValue: 0,
-                      maxValue: 65535,
-                      minStep: 0.001,
-                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-                      });
-        this.value = this.getDefaultValue();
-    };
-    CustomCharacteristic.KilowattHours.UUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
-    inherits(CustomCharacteristic.KilowattHours, Characteristic);
-    
-    CustomCharacteristic.KilowattVoltAmpereHour = function () {
-        Characteristic.call(this, 'Apparent Energy', CustomCharacteristic.KilowattVoltAmpereHour.UUID);
-        this.setProps({
-                      format: Characteristic.Formats.UINT32,
-                      unit: 'kVAh',
-                      minValue: 0,
-                      maxValue: 65535,
-                      minStep: 1,
-                      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
-                      });
-        this.value = this.getDefaultValue();
-    };
-    CustomCharacteristic.KilowattVoltAmpereHour.UUID = 'E863F127-079E-48FF-8F27-9C2605A29F52';
-    inherits(CustomCharacteristic.KilowattVoltAmpereHour, Characteristic);
+  CustomCharacteristic.KilowattHours = function () {
+    Characteristic.call(this, 'Total Consumption', CustomCharacteristic.KilowattHours.UUID);
+    this.setProps({
+      format: Characteristic.Formats.FLOAT,
+      unit: 'kWh',
+      minValue: 0,
+      maxValue: 65535,
+      minStep: 0.001,
+      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+    });
+    this.value = this.getDefaultValue();
+  };
+  CustomCharacteristic.KilowattHours.UUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
+  inherits(CustomCharacteristic.KilowattHours, Characteristic);
 
-    return {CustomCharacteristic};
+  CustomCharacteristic.KilowattVoltAmpereHour = function () {
+    Characteristic.call(this, 'Apparent Energy', CustomCharacteristic.KilowattVoltAmpereHour.UUID);
+    this.setProps({
+      format: Characteristic.Formats.UINT32,
+      unit: 'kVAh',
+      minValue: 0,
+      maxValue: 65535,
+      minStep: 1,
+      perms: [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+    });
+    this.value = this.getDefaultValue();
+  };
+  CustomCharacteristic.KilowattVoltAmpereHour.UUID = 'E863F127-079E-48FF-8F27-9C2605A29F52';
+  inherits(CustomCharacteristic.KilowattVoltAmpereHour, Characteristic);
+
+  return {CustomCharacteristic};
 };

--- a/lib/plug.js
+++ b/lib/plug.js
@@ -124,7 +124,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.Volts)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-            callback(null, Math.round(emeterRealtime.voltage));
+          	if (emeterRealtime.voltage == null) {
+              callback(null, Math.round(emeterRealtime.voltage_mv / 100) / 10);
+          	} else {
+              callback(null, Math.round(emeterRealtime.voltage));
+          	}
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'Volts emeter.getRealtime');
             this.log.error(reason);
@@ -135,7 +139,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.Amperes)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-            callback(null, Math.round(emeterRealtime.current));
+          	if (emeterRealtime.current == null) {
+              callback(null, Math.round(emeterRealtime.current_ma / 10) / 100);
+          	} else {
+              callback(null, Math.round(emeterRealtime.current));
+          	}
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'Amperes emeter.getRealtime');
             this.log.error(reason);
@@ -146,7 +154,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.Watts)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-            callback(null, Math.round(emeterRealtime.power));
+          	if (emeterRealtime.power == null) {
+              callback(null, Math.round(emeterRealtime.power_mw / 100) / 10);
+          	} else {
+              callback(null, Math.round(emeterRealtime.power));
+          	}
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'Watts emeter.getRealtime');
             this.log.error(reason);
@@ -157,7 +169,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.VoltAmperes)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-            callback(null, Math.round(emeterRealtime.voltage * emeterRealtime.current));
+          	if (emeterRealtime.voltage == null) {
+              callback(null, Math.round(emeterRealtime.voltage_mv * emeterRealtime.current_ma / 1000000));
+          	} else {
+              callback(null, Math.round(emeterRealtime.voltage * emeterRealtime.current));
+          	}
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'VoltAmperes emeter.getRealtime');
             this.log.error(reason);
@@ -168,7 +184,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.KilowattHours)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-            callback(null, Math.round(emeterRealtime.total));
+          	if (emeterRealtime.total == null) {
+              callback(null, Math.round(emeterRealtime.total_wh) / 1000);
+          	} else {
+              callback(null, Math.round(emeterRealtime.total));
+          	}
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'KilowattHours emeter.getRealtime');
             this.log.error(reason);

--- a/lib/plug.js
+++ b/lib/plug.js
@@ -124,11 +124,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.Volts)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-          	if (emeterRealtime.voltage == null) {
+            if (emeterRealtime.voltage == null) {
               callback(null, Math.round(emeterRealtime.voltage_mv / 100) / 10);
-          	} else {
+            } else {
               callback(null, Math.round(emeterRealtime.voltage));
-          	}
+            }
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'Volts emeter.getRealtime');
             this.log.error(reason);
@@ -139,11 +139,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.Amperes)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-          	if (emeterRealtime.current == null) {
+            if (emeterRealtime.current == null) {
               callback(null, Math.round(emeterRealtime.current_ma / 10) / 100);
-          	} else {
+            } else {
               callback(null, Math.round(emeterRealtime.current));
-          	}
+            }
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'Amperes emeter.getRealtime');
             this.log.error(reason);
@@ -154,11 +154,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.Watts)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-          	if (emeterRealtime.power == null) {
+            if (emeterRealtime.power == null) {
               callback(null, Math.round(emeterRealtime.power_mw / 100) / 10);
-          	} else {
+            } else {
               callback(null, Math.round(emeterRealtime.power));
-          	}
+            }
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'Watts emeter.getRealtime');
             this.log.error(reason);
@@ -169,11 +169,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.VoltAmperes)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-          	if (emeterRealtime.voltage == null) {
+            if (emeterRealtime.voltage == null) {
               callback(null, Math.round(emeterRealtime.voltage_mv * emeterRealtime.current_ma / 1000000));
-          	} else {
+            } else {
               callback(null, Math.round(emeterRealtime.voltage * emeterRealtime.current));
-          	}
+            }
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'VoltAmperes emeter.getRealtime');
             this.log.error(reason);
@@ -184,11 +184,11 @@ class PlugAccessory {
       getOrAddCharacteristic(this.outletService, CustomCharacteristic.KilowattHours)
         .on('get', (callback) => {
           this.plug.emeter.getRealtime().then((emeterRealtime) => {
-          	if (emeterRealtime.total == null) {
+            if (emeterRealtime.total == null) {
               callback(null, Math.round(emeterRealtime.total_wh) / 1000);
-          	} else {
+            } else {
               callback(null, Math.round(emeterRealtime.total));
-          	}
+            }
           }).catch((reason) => {
             this.log.error('[%s] %s', this.homebridgeAccessory.displayName, 'KilowattHours emeter.getRealtime');
             this.log.error(reason);


### PR DESCRIPTION
Updated all characteristic number formats to reflect updated formats found here: https://gist.github.com/simont77/3f4d4330fa55b83f8ca96388d9004e7d#elgato-eve-energy-firmware-revision-131466

Added compatibility with newer HS110 hardware and software revisions that return energy metrics in much smaller units. The threshold-based inUse state requires the corresponding fix in tplink-smarthome-api to function correctly.