### PR TITLE
fix: skip unsupported devices

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -58,20 +58,12 @@ class TplinkSmarthomePlatform {
 
     this.client.on('device-new', (device) => {
       this.log.info('New Device Online: [%s] %s [%s]', device.alias, device.deviceType, device.id, device.host, device.port);
-      if (this.isUnsupportedAccessory(device)) {
-        this.log.info('New Device Online: Device is unsupported. Skipping device so that homebridge can continue to boot & run %s', device.host, device.port);
-      } else {
         this.addAccessory(device);
-      }
     });
 
     this.client.on('device-online', (device) => {
       this.log.debug('Device Online: [%s] %s [%s]', device.alias, device.deviceType, device.id, device.host, device.port);
-      if (this.isUnsupportedAccessory(device)) {
-        this.log.debug('Device Online: Device %s is unsupported, skipping %s', device.host, device.port);
-      } else {
         this.addAccessory(device);
-      }
     });
 
     this.client.on('device-offline', (device) => {
@@ -83,7 +75,9 @@ class TplinkSmarthomePlatform {
 
     this.api.on('didFinishLaunching', () => {
       this.log.debug('didFinishLaunching');
-      this.client.startDiscovery(this.config.discoveryOptions);
+      this.client.startDiscovery({}, this.config.discoveryOptions, { filterCallback: (si) => {
+        return (si.deviceId != null && si.deviceId.length > 0);
+      } });
     });
   }
 
@@ -102,7 +96,10 @@ class TplinkSmarthomePlatform {
   addAccessory (device) {
     const deviceId = device.id;
 
-    if (this.isUnsupportedAccessory(device)) throw new Error('Missing deviceId');
+    if (deviceId == null || deviceId.length === 0) {
+      this.log.error('Missing deviceId');
+      return;
+    }
 
     let deviceAccessory = this.deviceAccessories.get(deviceId);
 
@@ -141,17 +138,6 @@ class TplinkSmarthomePlatform {
     this.deviceAccessories.delete(homebridgeAccessory.context.deviceId);
     this.homebridgeAccessories.delete(homebridgeAccessory.UUID);
     this.api.unregisterPlatformAccessories('homebridge-tplink-smarthome', 'TplinkSmarthome', [homebridgeAccessory]);
-  }
-
-  isUnsupportedAccessory(device){
-  	var retVal = false;
-
-  	if(device.id == null || device.id.length === 0){
-  		retVal = true;
-  		this.log.debug('Unsupported Accessory: DeviceId is missing and is therefore unsupported %s', device.host, device.port);
-  	}
-
-  	return retVal;
   }
 }
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -75,9 +75,9 @@ class TplinkSmarthomePlatform {
 
     this.api.on('didFinishLaunching', () => {
       this.log.debug('didFinishLaunching');
-      this.client.startDiscovery({}, this.config.discoveryOptions, { filterCallback: (si) => {
+      this.client.startDiscovery(Object.assign({}, this.config.discoveryOptions, { filterCallback: (si) => {
         return (si.deviceId != null && si.deviceId.length > 0);
-      } });
+      } }));
     });
   }
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -58,12 +58,12 @@ class TplinkSmarthomePlatform {
 
     this.client.on('device-new', (device) => {
       this.log.info('New Device Online: [%s] %s [%s]', device.alias, device.deviceType, device.id, device.host, device.port);
-        this.addAccessory(device);
+      this.addAccessory(device);
     });
 
     this.client.on('device-online', (device) => {
       this.log.debug('Device Online: [%s] %s [%s]', device.alias, device.deviceType, device.id, device.host, device.port);
-        this.addAccessory(device);
+      this.addAccessory(device);
     });
 
     this.client.on('device-offline', (device) => {

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -58,12 +58,20 @@ class TplinkSmarthomePlatform {
 
     this.client.on('device-new', (device) => {
       this.log.info('New Device Online: [%s] %s [%s]', device.alias, device.deviceType, device.id, device.host, device.port);
-      this.addAccessory(device);
+      if (device.deviceId == null || device.deviceId.length === 0) {
+        this.log.info('New Device Online: deviceId is null/blank and therefore is unsupported. homebridge-tplink-smarthome will continue to boot but device will not be available -- %s', device.host, device.port);
+      } else {
+        this.addAccessory(device);
+      }
     });
 
     this.client.on('device-online', (device) => {
       this.log.debug('Device Online: [%s] %s [%s]', device.alias, device.deviceType, device.id, device.host, device.port);
-      this.addAccessory(device);
+      if (device.deviceId == null || device.deviceId.length === 0) {
+        this.log.debug('Device Online: deviceId is null/blank and therefore is unsupported. homebridge-tplink-smarthome will continue to boot but device will not be available -- %s', device.host, device.port);
+      } else {
+        this.addAccessory(device);
+      }
     });
 
     this.client.on('device-offline', (device) => {

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -58,8 +58,8 @@ class TplinkSmarthomePlatform {
 
     this.client.on('device-new', (device) => {
       this.log.info('New Device Online: [%s] %s [%s]', device.alias, device.deviceType, device.id, device.host, device.port);
-      if (device.deviceId == null || device.deviceId.length === 0) {
-        this.log.info('New Device Online: deviceId is null/blank and therefore is unsupported. homebridge-tplink-smarthome will continue to boot but device will not be available -- %s', device.host, device.port);
+      if (this.isUnsupportedAccessory(device)) {
+        this.log.info('New Device Online: Device is unsupported. Skipping device so that homebridge can continue to boot & run %s', device.host, device.port);
       } else {
         this.addAccessory(device);
       }
@@ -67,8 +67,8 @@ class TplinkSmarthomePlatform {
 
     this.client.on('device-online', (device) => {
       this.log.debug('Device Online: [%s] %s [%s]', device.alias, device.deviceType, device.id, device.host, device.port);
-      if (device.deviceId == null || device.deviceId.length === 0) {
-        this.log.debug('Device Online: deviceId is null/blank and therefore is unsupported. homebridge-tplink-smarthome will continue to boot but device will not be available -- %s', device.host, device.port);
+      if (this.isUnsupportedAccessory(device)) {
+        this.log.debug('Device Online: Device %s is unsupported, skipping %s', device.host, device.port);
       } else {
         this.addAccessory(device);
       }
@@ -102,7 +102,7 @@ class TplinkSmarthomePlatform {
   addAccessory (device) {
     const deviceId = device.id;
 
-    if (deviceId == null || deviceId.length === 0) throw new Error('Missing deviceId');
+    if (this.isUnsupportedAccessory(device)) throw new Error('Missing deviceId');
 
     let deviceAccessory = this.deviceAccessories.get(deviceId);
 
@@ -141,6 +141,17 @@ class TplinkSmarthomePlatform {
     this.deviceAccessories.delete(homebridgeAccessory.context.deviceId);
     this.homebridgeAccessories.delete(homebridgeAccessory.UUID);
     this.api.unregisterPlatformAccessories('homebridge-tplink-smarthome', 'TplinkSmarthome', [homebridgeAccessory]);
+  }
+
+  isUnsupportedAccessory(device){
+  	var retVal = false;
+
+  	if(device.id == null || device.id.length === 0){
+  		retVal = true;
+  		this.log.debug('Unsupported Accessory: DeviceId is missing and is therefore unsupported %s', device.host, device.port);
+  	}
+
+  	return retVal;
   }
 }
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -97,7 +97,7 @@ class TplinkSmarthomePlatform {
     const deviceId = device.id;
 
     if (deviceId == null || deviceId.length === 0) {
-      this.log.error('Missing deviceId');
+      this.log.error('Missing deviceId: %s', device.host);
       return;
     }
 


### PR DESCRIPTION
Fix for issue #68 - add ability to ignore unsupported devices. This doesn't add support for KC120 camera, but by ignoring an unsupported device it allows homebridge-tplink-smarthome (and subsequently the rest of homebridge) to boot/run. 