### PR TITLE
Added status change logging

### DIFF
--- a/lib/homekit-device/bulb.js
+++ b/lib/homekit-device/bulb.js
@@ -58,9 +58,11 @@ class HomeKitDeviceBulb extends HomeKitDevice {
 
     this.tplinkDevice.on('lightstate-update', (lightState) => {
       if (lightState.on_off != null) {
+        this.log.info(`\x1b33m[${this.name}]\x1b[0m Updating state to: ${lightState.on_off}`);
         this.fireCharacteristicUpdateCallback(Characteristic.On, (lightState.on_off === 1));
       }
       if (lightState.brightness != null) {
+        this.log.info(`\x1b33m[${this.name}]\x1b[0m Updating brightness to: ${lightState.brightness}`);
         this.fireCharacteristicUpdateCallback(Characteristic.Brightness, lightState.brightness);
       }
       if (lightState.color_temp != null && lightState.color_temp > 0) {

--- a/lib/homekit-device/bulb.js
+++ b/lib/homekit-device/bulb.js
@@ -50,7 +50,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating state to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating state to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ on_off: value }, { transport: 'udp' });
       }
     });
@@ -95,7 +95,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating brightness to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating brightness to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ brightness: value }, { transport: 'udp' });
       }
     });
@@ -117,7 +117,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Color Temperature to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating Color Temperature to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ color_temp: Math.round(miredToKelvin(value)) }, { transport: 'udp' });
       }
     });
@@ -133,7 +133,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Hue to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating Hue to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ hue: value, color_temp: 0 }, { transport: 'udp' });
       }
     });
@@ -145,7 +145,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Saturation to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating Saturation to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ saturation: value, color_temp: 0 }, { transport: 'udp' });
       }
     });

--- a/lib/homekit-device/bulb.js
+++ b/lib/homekit-device/bulb.js
@@ -50,6 +50,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating state to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ on_off: value }, { transport: 'udp' });
       }
     });
@@ -58,11 +59,10 @@ class HomeKitDeviceBulb extends HomeKitDevice {
 
     this.tplinkDevice.on('lightstate-update', (lightState) => {
       if (lightState.on_off != null) {
-        this.log.info(`\x1b33m[${this.name}]\x1b[0m Updating state to: ${lightState.on_off}`);
         this.fireCharacteristicUpdateCallback(Characteristic.On, (lightState.on_off === 1));
       }
       if (lightState.brightness != null) {
-        this.log.info(`\x1b33m[${this.name}]\x1b[0m Updating brightness to: ${lightState.brightness}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating brightness to: ${lightState.brightness}`);
         this.fireCharacteristicUpdateCallback(Characteristic.Brightness, lightState.brightness);
       }
       if (lightState.color_temp != null && lightState.color_temp > 0) {

--- a/lib/homekit-device/bulb.js
+++ b/lib/homekit-device/bulb.js
@@ -50,7 +50,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating state to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating state to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ on_off: value }, { transport: 'udp' });
       }
     });
@@ -95,7 +95,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating brightness to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating brightness to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ brightness: value }, { transport: 'udp' });
       }
     });
@@ -117,7 +117,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating Color Temperature to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Color Temperature to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ color_temp: Math.round(miredToKelvin(value)) }, { transport: 'udp' });
       }
     });
@@ -133,7 +133,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating Hue to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Hue to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ hue: value, color_temp: 0 }, { transport: 'udp' });
       }
     });
@@ -145,7 +145,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating Saturation to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Saturation to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ saturation: value, color_temp: 0 }, { transport: 'udp' });
       }
     });

--- a/lib/homekit-device/bulb.js
+++ b/lib/homekit-device/bulb.js
@@ -62,7 +62,6 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         this.fireCharacteristicUpdateCallback(Characteristic.On, (lightState.on_off === 1));
       }
       if (lightState.brightness != null) {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating brightness to: ${lightState.brightness}`);
         this.fireCharacteristicUpdateCallback(Characteristic.Brightness, lightState.brightness);
       }
       if (lightState.color_temp != null && lightState.color_temp > 0) {
@@ -96,6 +95,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating brightness to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ brightness: value }, { transport: 'udp' });
       }
     });
@@ -117,6 +117,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Color Temperature to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ color_temp: Math.round(miredToKelvin(value)) }, { transport: 'udp' });
       }
     });
@@ -132,6 +133,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Hue to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ hue: value, color_temp: 0 }, { transport: 'udp' });
       }
     });
@@ -143,6 +145,7 @@ class HomeKitDeviceBulb extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating Saturation to: ${value}`);
         return this.tplinkDevice.lighting.setLightState({ saturation: value, color_temp: 0 }, { transport: 'udp' });
       }
     });

--- a/lib/homekit-device/plug.js
+++ b/lib/homekit-device/plug.js
@@ -52,7 +52,7 @@ class HomeKitDevicePlug extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating state to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating state to: ${value}`);
         return this.tplinkDevice.setPowerState(value);
       }
     });
@@ -80,7 +80,7 @@ class HomeKitDevicePlug extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating brightness to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating brightness to: ${value}`);
         return this.tplinkDevice.dimmer.setBrightness(value);
       }
     });

--- a/lib/homekit-device/plug.js
+++ b/lib/homekit-device/plug.js
@@ -52,7 +52,7 @@ class HomeKitDevicePlug extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating state to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating state to: ${value}`);
         return this.tplinkDevice.setPowerState(value);
       }
     });
@@ -80,7 +80,7 @@ class HomeKitDevicePlug extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
-        this.log.info(`\x1b[33m[${this.name}]\x1b[39m Updating brightness to: ${value}`);
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating brightness to: ${value}`);
         return this.tplinkDevice.dimmer.setBrightness(value);
       }
     });

--- a/lib/homekit-device/plug.js
+++ b/lib/homekit-device/plug.js
@@ -52,6 +52,7 @@ class HomeKitDevicePlug extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating state to: ${value}`);
         return this.tplinkDevice.setPowerState(value);
       }
     });
@@ -79,6 +80,7 @@ class HomeKitDevicePlug extends HomeKitDevice {
         });
       },
       setValue: async (value) => {
+        this.log.info(`\x1b[33m[${this.name}]\x1b[0m Updating brightness to: ${value}`);
         return this.tplinkDevice.dimmer.setBrightness(value);
       }
     });


### PR DESCRIPTION
I'm trying to troubleshoot my HomeKit automation and the Homebridge logs leave me blind to status changes of my TP-Link Bulb. This adds output to the logs when the lighting is changed.