### PR TITLE
Allow setting the discoveryConfig UDP port

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -33,11 +33,11 @@
           "type": "string"
         }
       },
-      "port": {
+      "discoveryPort": {
         "title": "Port",
         "type": "number",
-        "description": "Port to bind UDP socket for discovery, eg: 51826",
-        "placeholder": "51826",
+        "description": "Port to bind UDP socket for discovery. If port is not specified or is 0, the operating system will attempt to bind to a random port. Default: 0",
+        "placeholder": "0"
       },
       "broadcast": {
         "title": "Broadcast Address",
@@ -159,6 +159,7 @@
         "broadcast",
         "pollingInterval",
         "deviceTypes",
+        "discoveryPort",
         {
           "key": "macAddresses",
           "type": "array",

--- a/config.schema.json
+++ b/config.schema.json
@@ -33,6 +33,12 @@
           "type": "string"
         }
       },
+      "port": {
+        "title": "Port",
+        "type": "number",
+        "description": "Port to bind UDP socket for discovery, eg: 51826",
+        "placeholder": "51826",
+      },
       "broadcast": {
         "title": "Broadcast Address",
         "type": "string",

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export interface TplinkSmarthomeConfigInput {
   /**
    * port to bind udp socket
    */
-  port?: number | undefined;
+  discoveryPort?: number;
   /**
    * Broadcast Address. If discovery is not working tweak to match your subnet, eg: 192.168.0.255
    * @defaultValue '255.255.255.255'
@@ -87,6 +87,7 @@ type TplinkSmarthomeConfigDefault = {
   inUseThreshold: number;
   switchModels: Array<string>;
 
+  discoveryPort: number;
   broadcast: string;
   pollingInterval: number;
   deviceTypes: Array<'plug' | 'bulb'>;
@@ -132,7 +133,7 @@ export const defaultConfig: TplinkSmarthomeConfigDefault = {
   inUseThreshold: 0,
   switchModels: ['HS200', 'HS210'],
 
-  port: undefined,
+  discoveryPort: 0,
   broadcast: '255.255.255.255',
   pollingInterval: 10,
   deviceTypes: ['bulb', 'plug'],
@@ -160,6 +161,7 @@ function isTplinkSmarthomeConfigInput(
     (!('pollingInterval' in c) || typeof c.pollingInterval === 'number') &&
     (!('inUseThreshold' in c) || typeof c.inUseThreshold === 'number') &&
     (!('switchModels' in c) || isArrayOfStrings(c.switchModels)) &&
+    (!('discoveryPort' in c) || typeof c.discoveryPort === 'number') &&
     (!('deviceTypes' in c) || isArrayOfStrings(c.deviceTypes)) &&
     (!('waitTimeUpdate' in c) || typeof c.waitTimeUpdate === 'number')
   );
@@ -186,7 +188,7 @@ export function parseConfig(
     defaultSendOptions,
 
     discoveryOptions: {
-      port: c.port,
+      port: c.discoveryPort,
       broadcast: c.broadcast,
       discoveryInterval: c.pollingInterval * 1000,
       deviceTypes: c.deviceTypes,

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,10 @@ export interface TplinkSmarthomeConfigInput {
   // Discovery
   // ------------------
   /**
+   * port to bind udp socket
+   */
+  port?: number | undefined;
+  /**
    * Broadcast Address. If discovery is not working tweak to match your subnet, eg: 192.168.0.255
    * @defaultValue '255.255.255.255'
    */
@@ -106,6 +110,7 @@ export type TplinkSmarthomeConfig = {
   };
 
   discoveryOptions: {
+    port: number | undefined;
     broadcast: string;
     discoveryInterval: number;
     deviceTypes?: Array<'plug' | 'bulb'>;
@@ -127,6 +132,7 @@ export const defaultConfig: TplinkSmarthomeConfigDefault = {
   inUseThreshold: 0,
   switchModels: ['HS200', 'HS210'],
 
+  port: undefined,
   broadcast: '255.255.255.255',
   pollingInterval: 10,
   deviceTypes: ['bulb', 'plug'],
@@ -180,6 +186,7 @@ export function parseConfig(
     defaultSendOptions,
 
     discoveryOptions: {
+      port: c.port,
       broadcast: c.broadcast,
       discoveryInterval: c.pollingInterval * 1000,
       deviceTypes: c.deviceTypes,


### PR DESCRIPTION
This PR hopefully addresses this issue which I have also come across when locking down my server with UFW.

https://github.com/plasticrake/homebridge-tplink-smarthome/issues/118

Referenced https://plasticrake.github.io/tplink-smarthome-api/interfaces/_client_.discoveryoptions.html#port

Unfortunately, I was not able to install it in Homebridge from my fork to test, but was hoping you could look over the changes to give some insight on the direction needed to achieve this functionality.