### PR TITLE
Add TPLink KL50 bulb to supported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ TPLink Smart Home Plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 - **Plugs:** HS100, HS103, HS105, HS107, HS110, HS300, KP105, KP303, KP400
 - **Switches:** HS200, HS210, HS220
-- **Bulbs:** LB100, LB110, LB120, LB130, LB200, LB230
+- **Bulbs:** LB100, LB110, LB120, LB130, LB200, LB230, KL50
 
 More models may be supported than listed. If you have another model working please let me know so I can add here.
 
@@ -22,10 +22,11 @@ More models may be supported than listed. If you have another model working plea
 | HS100, HS103, HS105, HS107, KP105, KP303, KP400 | Outlet    | On<br/>OutletInUse (based on On state)                                                                                                                                                             |
 | HS110, HS300, KP115                             | Outlet    | On<br/>OutletInUse (based on energy monitoring)<br/>Volts (Custom)<br/>Amperes (Custom)<br/>Watts (Custom)<br/>VoltAmperes (Custom)<br/>KilowattHours (Custom)<br/>KilowattVoltAmpereHour (Custom) |
 | HS200, HS210                                    | Switch    | On                                                                                                                                                                                                 |
-| HS220                                           | Lightbulb | On<br/>Brightness                                                                                                                                                                                  |
+| HS220                                           | Lightbulb | On<br/>Brightness                                                                                                                                                                                  |         
 | LB100, LB110, LB200                             | Lightbulb | On<br/>Brightness<br/>Watts (Custom)                                                                                                                                                               |
 | LB120                                           | Lightbulb | On<br/>Brightness<br/>ColorTemperature<br/>Watts (Custom)                                                                                                                                          |
 | LB130, LB230                                    | Lightbulb | On<br/>Brightness<br/>ColorTemperature<br/>Hue<br/>Saturation<br/>Watts (Custom)                                                                                                                   |
+| KL50                                           | Lightbulb | On<br/>Brightness            
 
 ## Installation
 


### PR DESCRIPTION
I was able to successfully get my KL50 filament bulb working with this plugin by following the readme, so have added it to the table of supported accessories