### PR TITLE
Multi-Plug Devices as Power Strip Accessory in HomeKit

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -14,17 +14,23 @@
         "default": "TplinkSmarthome",
         "minLength": 1
       },
+      "powerStrip": {
+        "title": "Create Multi-Outlet Devices as a Power Strip",
+        "description": "Enable to create a single power strip accessory with multiple outlets, used for models HS107, KP200, HS300, KP303, KP400, and EP40. Default: false",
+        "type": "boolean",
+        "default": false
+      },
       "addCustomCharacteristics": {
         "title": "Adds energy monitoring characteristics viewable in Eve app",
-        "description": "<b>Plug</b>: Amperes, KilowattHours, VoltAmperes, Volts, Watts.<br/><b>Bulb</b>: Watts",
+        "description": "<b>Plug</b>: Amperes, KilowattHours, VoltAmperes, Volts, Watts.<br/><b>Bulb</b>: Watts</br>Default: false",
         "type": "boolean",
-        "default": true
+        "default": false
       },
       "emeterPollingInterval": {
         "title": "Energy Monitoring Polling Interval (seconds)",
         "type": "integer",
         "description": "How often to check device energy monitoring the background (seconds). Set to 0 to disable.",
-        "placeholder": "20"
+        "placeholder": "0"
       },
       "inUseThreshold": {
         "title": "In Use Threshold (Watts)",
@@ -118,8 +124,8 @@
       },
       "transport": {
         "type": "string",
-        "description": "Use TCP or UDP for device communication. Discovery will always use UDP. Default: TCP",
-        "placeholder": "tcp",
+        "description": "Use TCP or UDP for device communication. Discovery will always use UDP. Default: UDP",
+        "placeholder": "udp",
         "enum": ["tcp", "udp"],
         "titleMap": [
           { "name": "TCP", "value": "tcp" },
@@ -148,6 +154,7 @@
       "description": "Customize how devices are exposed in HomeKit",
       "expandable": true,
       "items": [
+        "powerStrip",
         "addCustomCharacteristics",
         "emeterPollingInterval",
         "inUseThreshold",

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,15 +54,21 @@ export interface TplinkSmarthomeConfigInput {
   // HomeKit
   // ------------------
   /**
+   * Create Multi-Outlet Devices as a Power Strip
+   * Enable to create a single power strip accessory with multiple outlets, used for models HS107, KP200, HS300, KP303, KP400, and EP40.
+   * @defaultValue false
+   */
+    powerStrip?: boolean;
+  /**
    * Adds energy monitoring characteristics viewable in Eve app
    * plug: Amperes, KilowattHours, VoltAmperes, Volts, Watts
    * bulb: Watts
-   * @defaultValue true
+   * @defaultValue false
    */
   addCustomCharacteristics?: boolean;
   /**
    * How often to check device energy monitoring the background (seconds). Set to 0 to disable.
-   * @defaultValue 20
+   * @defaultValue 0
    */
   emeterPollingInterval?: number;
   /**
@@ -125,6 +131,7 @@ export interface TplinkSmarthomeConfigInput {
   timeout?: number;
   /**
    * Use 'tcp' or 'udp' for device communication. Discovery will always use 'udp'
+   * @defaultValue "udp"
    */
   transport?: 'tcp' | 'udp';
   /**
@@ -141,6 +148,7 @@ export interface TplinkSmarthomeConfigInput {
 }
 
 type TplinkSmarthomeConfigDefault = {
+  powerStrip: boolean;
   addCustomCharacteristics: boolean;
   emeterPollingInterval: number;
   inUseThreshold: number;
@@ -161,6 +169,7 @@ type TplinkSmarthomeConfigDefault = {
 };
 
 export type TplinkSmarthomeConfig = {
+  powerStrip: boolean;
   addCustomCharacteristics: boolean;
   emeterPollingInterval: number;
   switchModels: Array<string>;
@@ -191,8 +200,9 @@ export type TplinkSmarthomeConfig = {
 };
 
 export const defaultConfig: TplinkSmarthomeConfigDefault = {
-  addCustomCharacteristics: true,
-  emeterPollingInterval: 20,
+  powerStrip: false,
+  addCustomCharacteristics: false,
+  emeterPollingInterval: 0,
   inUseThreshold: 0,
   switchModels: ['HS200', 'HS210'],
 
@@ -205,7 +215,7 @@ export const defaultConfig: TplinkSmarthomeConfigDefault = {
   devices: undefined,
 
   timeout: 15,
-  transport: undefined,
+  transport: 'udp',
   waitTimeUpdate: 100,
   devicesUseDiscoveryPort: false,
 };
@@ -238,6 +248,8 @@ function isTplinkSmarthomeConfigInput(
 ): c is TplinkSmarthomeConfigInput {
   return (
     isObjectLike(c) &&
+    (!('powerStrip' in c) ||
+      typeof c.powerStrip === 'boolean') &&
     (!('addCustomCharacteristics' in c) ||
       typeof c.addCustomCharacteristics === 'boolean') &&
     (!('emeterPollingInterval' in c) ||
@@ -288,6 +300,7 @@ export function parseConfig(
   };
 
   return {
+    powerStrip: Boolean(c.powerStrip),
     addCustomCharacteristics: Boolean(c.addCustomCharacteristics),
     emeterPollingInterval: c.emeterPollingInterval * 1000,
     switchModels: c.switchModels,

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,12 +60,6 @@ export interface TplinkSmarthomeConfigInput {
    */
     powerStrip?: boolean;
   /**
-   * Breakout Child Devices
-   * Enabled by default to breakout all child devices into individual accessories. If the powerStrip Option is enabled, this will be set to false.
-   * @defaultValue true
-   */
-    breakoutChildren?: boolean;
-  /**
    * Adds energy monitoring characteristics viewable in Eve app
    * plug: Amperes, KilowattHours, VoltAmperes, Volts, Watts
    * bulb: Watts
@@ -126,6 +120,12 @@ export interface TplinkSmarthomeConfigInput {
    * Manual list of devices (see "Manually Specifying Devices" section below)
    */
   devices?: Array<DeviceConfigInput>;
+  /**
+   * Breakout Child Devices
+   * Enabled by default to breakout all child devices into individual accessories. If the powerStrip Option is enabled, this will be set to false.
+   * @defaultValue true
+   */
+    breakoutChildren?: boolean;
 
   // ==================
   // Advanced Settings
@@ -155,7 +155,6 @@ export interface TplinkSmarthomeConfigInput {
 
 type TplinkSmarthomeConfigDefault = {
   powerStrip: boolean;
-  breakoutChildren: boolean;
   addCustomCharacteristics: boolean;
   emeterPollingInterval: number;
   inUseThreshold: number;
@@ -168,6 +167,7 @@ type TplinkSmarthomeConfigDefault = {
   macAddresses?: Array<string>;
   excludeMacAddresses?: Array<string>;
   devices?: Array<{ host: string; port?: number | undefined }>;
+  breakoutChildren: boolean;
 
   timeout: number;
   transport: 'tcp' | 'udp' | undefined;
@@ -177,7 +177,6 @@ type TplinkSmarthomeConfigDefault = {
 
 export type TplinkSmarthomeConfig = {
   powerStrip: boolean;
-  breakoutChildren: boolean;
   addCustomCharacteristics: boolean;
   emeterPollingInterval: number;
   switchModels: Array<string>;
@@ -204,12 +203,12 @@ export type TplinkSmarthomeConfig = {
     macAddresses?: Array<string>;
     excludeMacAddresses?: Array<string>;
     devices?: Array<{ host: string; port?: number | undefined }>;
+    breakoutChildren: boolean;
   };
 };
 
 export const defaultConfig: TplinkSmarthomeConfigDefault = {
   powerStrip: false,
-  breakoutChildren: true,
   addCustomCharacteristics: false,
   emeterPollingInterval: 0,
   inUseThreshold: 0,
@@ -222,6 +221,7 @@ export const defaultConfig: TplinkSmarthomeConfigDefault = {
   macAddresses: undefined,
   excludeMacAddresses: undefined,
   devices: undefined,
+  breakoutChildren: true,
 
   timeout: 15,
   transport: 'udp',
@@ -259,8 +259,6 @@ function isTplinkSmarthomeConfigInput(
     isObjectLike(c) &&
     (!('powerStrip' in c) ||
       typeof c.powerStrip === 'boolean') &&
-    (!('breakoutChildren' in c) ||
-      typeof c.breakoutChildren === 'boolean') &&
     (!('addCustomCharacteristics' in c) ||
       typeof c.addCustomCharacteristics === 'boolean') &&
     (!('emeterPollingInterval' in c) ||
@@ -280,6 +278,8 @@ function isTplinkSmarthomeConfigInput(
     (!('devices' in c) ||
       isArrayOfDeviceConfigInput(c.devices) ||
       c.devices === undefined) &&
+    (!('breakoutChildren' in c) ||
+      typeof c.breakoutChildren === 'boolean') &&
     (!('timeout' in c) || typeof c.timeout === 'number') &&
     (!('transport' in c) ||
       typeof c.transport === 'string' ||
@@ -312,7 +312,6 @@ export function parseConfig(
 
   return {
     powerStrip: Boolean(c.powerStrip),
-    breakoutChildren: c.powerStrip ? false : (c.breakoutChildren || true),
     addCustomCharacteristics: Boolean(c.addCustomCharacteristics),
     emeterPollingInterval: c.emeterPollingInterval * 1000,
     switchModels: c.switchModels,
@@ -334,6 +333,7 @@ export function parseConfig(
       macAddresses: c.macAddresses,
       excludeMacAddresses: c.excludeMacAddresses,
       devices: c.devices,
+      breakoutChildren: c.powerStrip ? false : (c.breakoutChildren || true)
     },
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,12 @@ export interface TplinkSmarthomeConfigInput {
    */
     powerStrip?: boolean;
   /**
+   * Breakout Child Devices
+   * Enabled by default to breakout all child devices into individual accessories. If the powerStrip Option is enabled, this will be set to false.
+   * @defaultValue true
+   */
+    breakoutChildren?: boolean;
+  /**
    * Adds energy monitoring characteristics viewable in Eve app
    * plug: Amperes, KilowattHours, VoltAmperes, Volts, Watts
    * bulb: Watts
@@ -149,6 +155,7 @@ export interface TplinkSmarthomeConfigInput {
 
 type TplinkSmarthomeConfigDefault = {
   powerStrip: boolean;
+  breakoutChildren: boolean;
   addCustomCharacteristics: boolean;
   emeterPollingInterval: number;
   inUseThreshold: number;
@@ -170,6 +177,7 @@ type TplinkSmarthomeConfigDefault = {
 
 export type TplinkSmarthomeConfig = {
   powerStrip: boolean;
+  breakoutChildren: boolean;
   addCustomCharacteristics: boolean;
   emeterPollingInterval: number;
   switchModels: Array<string>;
@@ -201,6 +209,7 @@ export type TplinkSmarthomeConfig = {
 
 export const defaultConfig: TplinkSmarthomeConfigDefault = {
   powerStrip: false,
+  breakoutChildren: true,
   addCustomCharacteristics: false,
   emeterPollingInterval: 0,
   inUseThreshold: 0,
@@ -250,6 +259,8 @@ function isTplinkSmarthomeConfigInput(
     isObjectLike(c) &&
     (!('powerStrip' in c) ||
       typeof c.powerStrip === 'boolean') &&
+    (!('breakoutChildren' in c) ||
+      typeof c.breakoutChildren === 'boolean') &&
     (!('addCustomCharacteristics' in c) ||
       typeof c.addCustomCharacteristics === 'boolean') &&
     (!('emeterPollingInterval' in c) ||
@@ -301,6 +312,7 @@ export function parseConfig(
 
   return {
     powerStrip: Boolean(c.powerStrip),
+    breakoutChildren: c.powerStrip ? false : (c.breakoutChildren || true),
     addCustomCharacteristics: Boolean(c.addCustomCharacteristics),
     emeterPollingInterval: c.emeterPollingInterval * 1000,
     switchModels: c.switchModels,

--- a/src/homekit-device/create.ts
+++ b/src/homekit-device/create.ts
@@ -30,7 +30,7 @@ export default function create(
       homebridgeAccessory,
       tplinkDevice
     );
-  } else if (powerStripModels.includes(tplinkDevice.model) && config.powerStrip) {
+  } else if (powerStripModels.includes(tplinkDevice.model.slice(0,-4)) && config.powerStrip) {
     return new HomeKitDevicePowerStrip(
       platform,
       config,

--- a/src/homekit-device/create.ts
+++ b/src/homekit-device/create.ts
@@ -7,6 +7,7 @@ import type { TplinkDevice } from '../utils';
 import HomekitDevice from '.';
 import HomeKitDeviceBulb from './bulb';
 import HomeKitDevicePlug from './plug';
+import HomeKitDevicePowerStrip from './powerstrip';
 import { TplinkSmarthomeConfig } from '../config';
 
 /**
@@ -20,8 +21,17 @@ export default function create(
     | undefined,
   tplinkDevice: TplinkDevice
 ): HomekitDevice {
+  const powerStripModels = ['HS107', 'KP200', 'HS300', 'KP303', 'KP400', 'EP40'];
+
   if (tplinkDevice.deviceType === 'bulb') {
     return new HomeKitDeviceBulb(
+      platform,
+      config,
+      homebridgeAccessory,
+      tplinkDevice
+    );
+  } else if (powerStripModels.includes(tplinkDevice.model) && config.powerStrip) {
+    return new HomeKitDevicePowerStrip(
       platform,
       config,
       homebridgeAccessory,

--- a/src/homekit-device/index.ts
+++ b/src/homekit-device/index.ts
@@ -150,7 +150,7 @@ export default abstract class HomekitDevice {
     characteristic: Characteristic,
     value: Nullable<CharacteristicValue> | Error | HapStatusError
   ) {
-    this.log.debug(`Updating ${this.lsc(service, characteristic)} on ${service} to ${value}`);
+    this.log.debug(`Updating ${this.lsc(service, characteristic)} on ${this.lsc(service)} to ${value}`);
     characteristic.updateValue(value);
   }
 

--- a/src/homekit-device/index.ts
+++ b/src/homekit-device/index.ts
@@ -12,6 +12,8 @@ import type {
   WithUUID,
 } from 'homebridge';
 
+import type { PlugChild } from 'tplink-smarthome-api';
+
 import chalk from 'chalk';
 
 import AccessoryInformation from '../accessory-information';
@@ -157,9 +159,10 @@ export default abstract class HomekitDevice {
   updateChildValue(
     service: Service,
     characteristic: Characteristic,
-    value: Nullable<CharacteristicValue> | Error | HapStatusError
+    value: Nullable<CharacteristicValue> | Error | HapStatusError,
+    childDevice: PlugChild
   ) {
-    this.log.debug(`Updating ${this.lsc(service, characteristic)} on ${this.lsc(service)} to ${value}`);
+    this.log.debug(`Updating ${this.lsc(service, characteristic)} on ${childDevice.alias} to ${value}`);
     characteristic.updateValue(value);
   }
 

--- a/src/homekit-device/index.ts
+++ b/src/homekit-device/index.ts
@@ -76,7 +76,7 @@ export default abstract class HomekitDevice {
       );
       this.homebridgeAccessory.displayName = this.name;
       if (this.homebridgeAccessory.category !== category) {
-        this.log.warn(
+        this.log.debug(
           `Correcting Accessory Category from: ${platform.getCategoryName(
             this.homebridgeAccessory.category
           )} to: ${categoryName}`
@@ -101,7 +101,7 @@ export default abstract class HomekitDevice {
       if (service instanceof platform.Service.Lightbulb) return;
       if (service instanceof platform.Service.Outlet) return;
       if (service instanceof platform.Service.Switch) return;
-      this.log.warn(
+      this.log.debug(
         `Removing stale Service: ${this.lsc(service)} uuid:[%s] subtype:[%s]`,
         service.UUID,
         service.subtype || ''
@@ -158,11 +158,12 @@ export default abstract class HomekitDevice {
     serviceConstructor:
       | typeof this.platform.Service.Outlet
       | typeof this.platform.Service.Lightbulb, // WithUUID<Service | typeof Service>,
-    name: string
+    name: string,
+    subType?: string
   ) {
     const serviceName = this.platform.getServiceName(serviceConstructor);
-    this.log.debug(`Creating new ${serviceName} Service`);
-    return this.homebridgeAccessory.addService(serviceConstructor, name);
+    this.log.debug(`Creating new ${serviceName} Service on ${name}${subType ? ` [${subType}]` : ''}`);
+    return this.homebridgeAccessory.addService(serviceConstructor, name, subType);
   }
 
   protected logRejection(reason: unknown): void {
@@ -172,7 +173,7 @@ export default abstract class HomekitDevice {
   protected removeServiceIfExists(service: WithUUID<typeof Service>) {
     const foundService = this.homebridgeAccessory.getService(service);
     if (foundService != null) {
-      this.log.warn(
+      this.log.debug(
         `Removing stale Service: ${this.lsc(service, foundService)} uuid:[%s]`,
         foundService.UUID
       );
@@ -192,7 +193,7 @@ export default abstract class HomekitDevice {
       )
     ) {
       const characteristicToRemove = service.getCharacteristic(characteristic);
-      this.log.warn(
+      this.log.debug(
         `Removing stale Characteristic: ${this.lsc(
           service,
           characteristicToRemove

--- a/src/homekit-device/index.ts
+++ b/src/homekit-device/index.ts
@@ -150,7 +150,7 @@ export default abstract class HomekitDevice {
     characteristic: Characteristic,
     value: Nullable<CharacteristicValue> | Error | HapStatusError
   ) {
-    this.log.debug(`Updating ${this.lsc(service, characteristic)} ${value}`);
+    this.log.debug(`Updating ${this.lsc(service, characteristic)} on ${service} to ${value}`);
     characteristic.updateValue(value);
   }
 

--- a/src/homekit-device/index.ts
+++ b/src/homekit-device/index.ts
@@ -162,8 +162,10 @@ export default abstract class HomekitDevice {
     value: Nullable<CharacteristicValue> | Error | HapStatusError,
     childDevice: PlugChild
   ) {
-    this.log.debug(`Updating ${this.lsc(service, characteristic)} on ${childDevice.alias} to ${value}`);
-    characteristic.updateValue(value);
+    const homekitState = value === 1 ? true : false;
+
+    this.log.debug(`Updating ${this.lsc(service, characteristic)} on ${childDevice.alias} to ${homekitState}`);
+    characteristic.updateValue(homekitState);
   }
 
   addService(

--- a/src/homekit-device/index.ts
+++ b/src/homekit-device/index.ts
@@ -154,6 +154,15 @@ export default abstract class HomekitDevice {
     characteristic.updateValue(value);
   }
 
+  updateChildValue(
+    service: Service,
+    characteristic: Characteristic,
+    value: Nullable<CharacteristicValue> | Error | HapStatusError
+  ) {
+    this.log.debug(`Updating ${this.lsc(service, characteristic)} on ${this.lsc(service)} to ${value}`);
+    characteristic.updateValue(value);
+  }
+
   addService(
     serviceConstructor:
       | typeof this.platform.Service.Outlet

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -101,9 +101,9 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
         this.log.info(`Setting On to: ${value} for ${childDevice.alias}`);
         if (typeof value === 'boolean') {
           if (value === true) {
-              var command = { 'system': { 'set_relay_state': { 'state': 1, 'context': { 'child_ids': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
+              var command = { 'system': { 'set_relay_state': { 'state': 1, 'context': { 'child_ids': [`${this.tplinkDevice.id}0${childDevice.id}`] } } } };
             } else {
-              var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
+              var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': [`${this.tplinkDevice.id}0${childDevice.id}`] } } } };
           }
           const responseString = await this.tplinkDevice.send(command);
           this.log.debug(`Response: ${responseString}`);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -95,7 +95,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     onCharacteristic
       .onGet(() => {
         this.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
-        return childDevice.state; // immediately returned cached value
+        return this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state ?? false; // immediately returned cached value
       })
       .onSet(async (value) => {
         this.log.info(`Setting On to: ${value} for ${childDevice.alias}`);
@@ -113,8 +113,8 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     let oldChildState = childDevice.state;
 
     this.tplinkDevice.on('power-update', async () => {
-      const sysInfo = await this.tplinkDevice.getSysInfo();
-      const newChildState = sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
+      await this.getSysInfo().catch(this.logRejection.bind(this));;
+      const newChildState = this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
       
       if (newChildState) {
         if (newChildState !== oldChildState) {

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -94,7 +94,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
 
     onCharacteristic
       .onGet(() => {
-        this.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
+        this.tplinkDevice.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
         return this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state ?? false; // immediately returned cached value
       })
       .onSet(async (value) => {
@@ -113,7 +113,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     let oldChildState = childDevice.state;
 
     this.tplinkDevice.on('power-update', async () => {
-      await this.getSysInfo().catch(this.logRejection.bind(this));;
+      await this.tplinkDevice.getSysInfo().catch(this.logRejection.bind(this));;
       const newChildState = this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
       
       if (newChildState) {

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -112,8 +112,9 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
 
     let oldChildState = childDevice.state;
 
-    this.tplinkDevice.on('power-update', () => {
-      const newChildState = this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
+    this.tplinkDevice.on('power-update', async () => {
+      const sysInfo = await this.tplinkDevice.getSysInfo();
+      const newChildState = sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
       
       if (newChildState) {
         if (newChildState !== oldChildState) {

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -94,8 +94,8 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
 
     onCharacteristic
       .onGet(() => {
-        this.tplinkDevice.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
-        this.log.debug(`Current State of ${childDevice.alias} is ${childDevice.state}`);
+        this.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
+        this.log.debug(`Current State of On is: ${childDevice.state === 1 ? true : false} for ${childDevice.alias}`);
         return childDevice.state; // immediately returned cached value
       })
       .onSet(async (value) => {

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -110,7 +110,18 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
         throw new Error(`setValue: Invalid On: ${value}`);
       });
 
-    onCharacteristic.updateValue(childDevice.state);
+    let oldChildState = childDevice.state;
+
+    this.tplinkDevice.on('power-update', () => {
+      const newChildState = this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
+      
+      if (newChildState) {
+        if (newChildState !== oldChildState) {
+          oldChildState = newChildState;
+          this.updateChildValue(outletService, onCharacteristic, newChildState);
+        }
+      }
+    });
 
     return outletService;
   }

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -93,10 +93,14 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     );
 
     onCharacteristic
-      .onGet(() => {
-        this.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
-        this.log.debug(`Current State of On is: ${childDevice.state === 1 ? true : false} for ${childDevice.alias}`);
-        return childDevice.state; // immediately returned cached value
+      .onGet(async () => {
+        const sysInfo = await this.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
+        if (sysInfo) {
+          const childState = sysInfo.children?.find(child => child.id === childDevice.id)?.state;
+          this.log.debug(`Current State of On is: ${childState === 1 ? true : false} for ${childDevice.alias}`);
+          return childState ?? 0; // immediately returned cached value
+        }
+        return 0;
       })
       .onSet(async (value) => {
         this.log.info(`Setting On to: ${value} for ${childDevice.alias}`);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -138,10 +138,11 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
           const child = this.tplinkDevice.sysInfo.children?.find(child => child.id === childDevice.id);
           if (child) {
             if (value === true) {
-              child.state = 1;
+              var command = { 'system': { 'set_relay_state': { 'state': 1, 'context': { 'child_ids': [childDevice.id] } } } };
             } else {
-              child.state = 0;
+              var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': [childDevice.id] } } } };
             }
+            this.tplinkDevice.send(command);
           } else {
             await this.setPowerState(value);
           }

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -10,7 +10,6 @@ import type { TplinkSmarthomeAccessoryContext } from '../platform';
 import { deferAndCombine, getOrAddCharacteristic } from '../utils';
 
 export default class HomeKitDevicePowerStrip extends HomekitDevice {
-  private desiredPowerState?: boolean;
 
   constructor(
     platform: TplinkSmarthomePlatform,
@@ -41,30 +40,6 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
       return this.tplinkDevice.getSysInfo();
     }, platform.config.waitTimeUpdate);
 
-    this.setPowerState = deferAndCombine(
-      async (requestCount) => {
-        this.log.debug(
-          `executing deferred setPowerState count: ${requestCount}`
-        );
-        if (this.desiredPowerState === undefined) {
-          this.log.warn(
-            'setPowerState called with undefined desiredPowerState'
-          );
-          return Promise.resolve(true);
-        }
-
-        const ret = await this.tplinkDevice.setPowerState(
-          this.desiredPowerState
-        );
-        this.desiredPowerState = undefined;
-        return ret;
-      },
-      platform.config.waitTimeUpdate,
-      (value: boolean) => {
-        this.desiredPowerState = value;
-      }
-    );
-
     this.getRealtime = deferAndCombine((requestCount) => {
       this.log.debug(`executing deferred getRealtime count: ${requestCount}`);
       return this.tplinkDevice.emeter.getRealtime();
@@ -77,13 +52,6 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
    * @private
    */
   private getSysInfo: () => Promise<PlugSysinfo>;
-
-  /**
-   * Aggregates setPowerState requests
-   *
-   * @private
-   */
-  private setPowerState: (value: boolean) => Promise<true>;
 
   /**
    * Aggregates getRealtime requests

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -105,7 +105,12 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
             } else {
               var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': [childDevice.id] } } } };
           }
-          await this.tplinkDevice.send(command);
+          const responseString = await this.tplinkDevice.send(command);
+          const response = JSON.parse(responseString);
+          if (response.system.set_relay_state.err_code !== 0) {
+            this.log.warn('Failed to set relay state:', response.system.set_relay_state.err_msg);
+            throw new Error(`Failed to set relay state: ${response.system.set_relay_state.err_msg}`);
+          }
           return;
         }
         this.log.warn('setValue: Invalid On:', value);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -106,7 +106,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
               var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': [`${this.tplinkDevice.id}0${childDevice.id}`] } } } };
           }
           const responseString = await this.tplinkDevice.sendCommand(command);
-          this.log.debug(`Response: ${responseString}`);
+          this.log.debug(`${this.tplinkDevice.id}0${childDevice.id} Response: ${responseString}`);
           return;
         }
         this.log.warn('setValue: Invalid On:', value);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -104,7 +104,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
 
   private configureOutletService(service: Service, child: PlugChild, index: number) {
 
-    this.addOnCharacteristic(service, child.alias, child.id, index);
+    this.addOnCharacteristic(service, child, index);
 
     this.addOutletInUseCharacteristic(service);
 
@@ -120,7 +120,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     return service;
   }
 
-  private addOnCharacteristic(service: Service, childAlias: string, childId: string, index: number) {
+  private addOnCharacteristic(service: Service, childDevice: PlugChild, index: number) {
     const onCharacteristic = getOrAddCharacteristic(
       service,
       this.platform.Characteristic.On
@@ -129,13 +129,13 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     onCharacteristic
       .onGet(() => {
         this.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
-        const child = this.tplinkDevice.sysInfo.children?.find(child => child.id === childId);
+        const child = this.tplinkDevice.sysInfo.children?.find(child => child.id === childDevice.id);
         return child ? child.state : this.tplinkDevice.relayState; // immediately returned cached value
       })
       .onSet(async (value) => {
-        this.log.info(`Setting On to: ${value} for ${childAlias} [outlet-${index + 1}]`);
+        this.log.info(`Setting On to: ${value} for ${childDevice.alias} [outlet-${index + 1}]`);
         if (typeof value === 'boolean') {
-          const child = this.tplinkDevice.sysInfo.children?.find(child => child.id === childId);
+          const child = this.tplinkDevice.sysInfo.children?.find(child => child.id === childDevice.id);
           if (child) {
             if (value === true) {
               child.state = 1;

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -105,7 +105,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
             } else {
               var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'childIds': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
           }
-          const responseString = await this.tplinkDevice.send(command);
+          const responseString = await this.tplinkDevice.sendCommand(command);
           this.log.debug(`Response: ${responseString}`);
           return;
         }

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -101,11 +101,11 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
         this.log.info(`Setting On to: ${value} for ${childDevice.alias}`);
         if (typeof value === 'boolean') {
           if (value === true) {
-              var command = { 'system': { 'set_relay_state': { 'state': 1, 'context': { 'childIds': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
+              var command = { 'system': { 'set_relay_state': { 'state': 1, 'context': { 'child_ids': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
             } else {
-              var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'childIds': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
+              var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
           }
-          const responseString = await this.tplinkDevice.sendCommand(command);
+          const responseString = await this.tplinkDevice.send(command);
           this.log.debug(`Response: ${responseString}`);
           return;
         }

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -27,16 +27,16 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
       Categories.OUTLET
     );
 
+    this.getSysInfo = deferAndCombine((requestCount) => {
+      this.log.debug(`executing deferred getSysInfo count: ${requestCount}`);
+      return this.tplinkDevice.getSysInfo();
+    }, platform.config.waitTimeUpdate);
+
     this.tplinkDevice.sysInfo.children?.forEach((child, index) => {
       const outletService = this.addOutletService(child, index);
 
       this.configureOutletService(outletService, child);
     });
-
-    this.getSysInfo = deferAndCombine((requestCount) => {
-      this.log.debug(`executing deferred getSysInfo count: ${requestCount}`);
-      return this.tplinkDevice.getSysInfo();
-    }, platform.config.waitTimeUpdate);
 
     this.getRealtime = deferAndCombine((requestCount) => {
       this.log.debug(`executing deferred getRealtime count: ${requestCount}`);
@@ -95,7 +95,8 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     onCharacteristic
       .onGet(() => {
         this.tplinkDevice.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
-        return this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state ?? false; // immediately returned cached value
+        this.log.debug(`Current State of ${childDevice.alias} is ${childDevice.state}`);
+        return childDevice.state; // immediately returned cached value
       })
       .onSet(async (value) => {
         this.log.info(`Setting On to: ${value} for ${childDevice.alias}`);
@@ -118,11 +119,13 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
       
       if (newChildState) {
         if (newChildState !== oldChildState) {
-          oldChildState = newChildState;
           this.updateChildValue(outletService, onCharacteristic, newChildState, childDevice);
         }
       }
+
+      oldChildState = newChildState ?? 0;
     });
+
 
     return outletService;
   }

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -106,10 +106,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
               var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'childIds': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
           }
           const responseString = await this.tplinkDevice.send(command);
-          const response = JSON.parse(responseString);
-
-          this.log.warn(`Command: ${command} Response: ${response}`);
-
+          this.log.debug(`Response: ${responseString}`);
           return;
         }
         this.log.warn('setValue: Invalid On:', value);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -28,7 +28,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     );
 
     this.tplinkDevice.sysInfo.children?.forEach((child, index) => {
-      const outletService = this.addAndConfigureOutletService(child, index);
+      this.addAndConfigureOutletService(child, index);
     });
 
     this.getSysInfo = deferAndCombine((requestCount) => {

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -105,7 +105,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
             } else {
               var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': [`${this.tplinkDevice.id}0${childDevice.id}`] } } } };
           }
-          const responseString = await this.tplinkDevice.send(command);
+          const responseString = await this.tplinkDevice.sendCommand(command);
           this.log.debug(`Response: ${responseString}`);
           return;
         }

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -107,10 +107,9 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
           }
           const responseString = await this.tplinkDevice.send(command);
           const response = JSON.parse(responseString);
-          if (response.system.set_relay_state.err_code !== 0) {
-            this.log.warn('Failed to set relay state:', response.system.set_relay_state.err_msg);
-            throw new Error(`Failed to set relay state: ${response.system.set_relay_state.err_msg}`);
-          }
+
+          this.log.warn(`Command: ${command} Response: ${response}`);
+
           return;
         }
         this.log.warn('setValue: Invalid On:', value);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -111,19 +111,17 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
         throw new Error(`setValue: Invalid On: ${value}`);
       });
 
-    let oldChildState = childDevice.state;
+      let oldChildState = childDevice.state;
 
-    this.tplinkDevice.on('power-update', async () => {
-      const newChildState = this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
+      setInterval(async () => {
+        const sysInfo = await this.tplinkDevice.getSysInfo();
+        const newChildState = sysInfo.children?.find(child => child.id === childDevice.id)?.state;
       
-      if (newChildState) {
-        if (newChildState !== oldChildState) {
+        if (newChildState !== undefined && newChildState !== oldChildState) {
           this.updateChildValue(outletService, onCharacteristic, newChildState, childDevice);
+          oldChildState = newChildState;
         }
-      }
-
-      oldChildState = newChildState ?? 0;
-    });
+      }, 5000); // Poll every 5 seconds
 
 
     return outletService;

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -100,13 +100,10 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
       .onSet(async (value) => {
         this.log.info(`Setting On to: ${value} for ${childDevice.alias}`);
         if (typeof value === 'boolean') {
-          if (value === true) {
-              var command = { 'system': { 'set_relay_state': { 'state': 1, 'context': { 'child_ids': [`${this.tplinkDevice.id}0${childDevice.id}`] } } } };
-            } else {
-              var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': [`${this.tplinkDevice.id}0${childDevice.id}`] } } } };
-          }
-          const responseString = await this.tplinkDevice.sendCommand(command);
-          this.log.debug(`${this.tplinkDevice.id}0${childDevice.id} Response: ${responseString}`);
+          await this.tplinkDevice.sendCommand(
+            `{"system":{"set_relay_state":{"state":${value ? 1 : 0}}}}`,
+            childDevice.id,
+          );
           return;
         }
         this.log.warn('setValue: Invalid On:', value);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -101,9 +101,9 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
         this.log.info(`Setting On to: ${value} for ${childDevice.alias}`);
         if (typeof value === 'boolean') {
           if (value === true) {
-              var command = { 'system': { 'set_relay_state': { 'state': 1, 'context': { 'child_ids': [childDevice.id] } } } };
+              var command = { 'system': { 'set_relay_state': { 'state': 1, 'context': { 'childIds': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
             } else {
-              var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'child_ids': [childDevice.id] } } } };
+              var command = { 'system': { 'set_relay_state': { 'state': 0, 'context': { 'childIds': `${this.tplinkDevice.id}0${childDevice.id}` } } } };
           }
           const responseString = await this.tplinkDevice.send(command);
           const response = JSON.parse(responseString);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -113,13 +113,13 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     let oldChildState = childDevice.state;
 
     this.tplinkDevice.on('power-update', async () => {
-      await this.tplinkDevice.getSysInfo().catch(this.logRejection.bind(this));;
-      const newChildState = this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
+      const sysInfo = await this.tplinkDevice.getSysInfo();
+      const newChildState = sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
       
       if (newChildState) {
         if (newChildState !== oldChildState) {
           oldChildState = newChildState;
-          this.updateChildValue(outletService, onCharacteristic, newChildState);
+          this.updateChildValue(outletService, onCharacteristic, newChildState, childDevice);
         }
       }
     });

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -114,8 +114,7 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
     let oldChildState = childDevice.state;
 
     this.tplinkDevice.on('power-update', async () => {
-      const sysInfo = await this.tplinkDevice.getSysInfo();
-      const newChildState = sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
+      const newChildState = this.tplinkDevice.sysInfo.children?.find(childDevice => childDevice.id === childDevice.id)?.state;
       
       if (newChildState) {
         if (newChildState !== oldChildState) {

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -1,0 +1,265 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Categories } from 'homebridge'; // enum
+import type { Service, PlatformAccessory } from 'homebridge';
+import type { Plug, PlugChild, PlugSysinfo } from 'tplink-smarthome-api';
+
+import HomekitDevice from '.';
+import { TplinkSmarthomeConfig } from '../config';
+import type TplinkSmarthomePlatform from '../platform';
+import type { TplinkSmarthomeAccessoryContext } from '../platform';
+import { deferAndCombine, getOrAddCharacteristic } from '../utils';
+
+export default class HomeKitDevicePowerStrip extends HomekitDevice {
+  private desiredPowerState?: boolean;
+
+  constructor(
+    platform: TplinkSmarthomePlatform,
+    readonly config: TplinkSmarthomeConfig,
+    homebridgeAccessory:
+      | PlatformAccessory<TplinkSmarthomeAccessoryContext>
+      | undefined,
+    readonly tplinkDevice: Plug
+  ) {
+    super(
+      platform,
+      config,
+      homebridgeAccessory,
+      tplinkDevice,
+      Categories.OUTLET
+    );
+
+    tplinkDevice.sysInfo.children?.forEach((child, index) => {
+      var service = this.addOutletService(child, index);
+
+      service = this.configureOutletService(service, child, index);
+    });
+
+    this.getSysInfo = deferAndCombine((requestCount) => {
+      this.log.debug(`executing deferred getSysInfo count: ${requestCount}`);
+      return this.tplinkDevice.getSysInfo();
+    }, platform.config.waitTimeUpdate);
+
+    this.setPowerState = deferAndCombine(
+      async (requestCount) => {
+        this.log.debug(
+          `executing deferred setPowerState count: ${requestCount}`
+        );
+        if (this.desiredPowerState === undefined) {
+          this.log.warn(
+            'setPowerState called with undefined desiredPowerState'
+          );
+          return Promise.resolve(true);
+        }
+
+        const ret = await this.tplinkDevice.setPowerState(
+          this.desiredPowerState
+        );
+        this.desiredPowerState = undefined;
+        return ret;
+      },
+      platform.config.waitTimeUpdate,
+      (value: boolean) => {
+        this.desiredPowerState = value;
+      }
+    );
+
+    this.getRealtime = deferAndCombine((requestCount) => {
+      this.log.debug(`executing deferred getRealtime count: ${requestCount}`);
+      return this.tplinkDevice.emeter.getRealtime();
+    }, platform.config.waitTimeUpdate);
+  }
+
+  /**
+   * Aggregates getSysInfo requests
+   *
+   * @private
+   */
+  private getSysInfo: () => Promise<PlugSysinfo>;
+
+  /**
+   * Aggregates setPowerState requests
+   *
+   * @private
+   */
+  private setPowerState: (value: boolean) => Promise<true>;
+
+  /**
+   * Aggregates getRealtime requests
+   *
+   * @private
+   */
+  private getRealtime: () => Promise<unknown>;
+
+  private addOutletService(child: PlugChild, index: number) {
+    const { Outlet } = this.platform.Service;
+
+    const outletService =
+      this.homebridgeAccessory.getServiceById(Outlet, `outlet-${index + 1}`) ??
+      this.addService(Outlet, child.alias, `outlet-${index + 1}`);
+
+    return outletService;
+  }
+
+  private configureOutletService(service: Service, child: PlugChild, index: number) {
+
+    this.addOnCharacteristic(service, child.alias, index);
+
+    this.addOutletInUseCharacteristic(service);
+
+    if (
+      this.platform.config.addCustomCharacteristics &&
+      this.tplinkDevice.supportsEmeter
+    ) {
+      this.addEnergyCharacteristics(service);
+    } else {
+      this.removeEnergyCharacteristics(service);
+    }
+
+    return service;
+  }
+
+  private addOnCharacteristic(service: Service, alias: string, index: number) {
+    const onCharacteristic = getOrAddCharacteristic(
+      service,
+      this.platform.Characteristic.On
+    );
+
+    onCharacteristic
+      .onGet(() => {
+        this.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
+        return this.tplinkDevice.relayState; // immediately returned cached value
+      })
+      .onSet(async (value) => {
+        this.log.info(`Setting On to: ${value} for ${alias} [outlet-${index + 1}]`);
+        if (typeof value === 'boolean') {
+          await this.setPowerState(value);
+          return;
+        }
+        this.log.warn('setValue: Invalid On:', value);
+        throw new Error(`setValue: Invalid On: ${value}`);
+      });
+
+    this.tplinkDevice.on('power-update', (value) => {
+      this.updateValue(service, onCharacteristic, value);
+    });
+
+    return service;
+  }
+
+  private addOutletInUseCharacteristic(service: Service) {
+    const outletInUseCharacteristic = getOrAddCharacteristic(
+        service,
+        this.platform.Characteristic.OutletInUse
+      );
+
+      outletInUseCharacteristic.onGet(() => {
+        this.getSysInfo().catch(this.logRejection.bind(this)); // this will eventually trigger update
+        return this.tplinkDevice.inUse; // immediately returned cached value
+      });
+
+      this.tplinkDevice.on('in-use-update', (value) => {
+        this.updateValue(service, outletInUseCharacteristic, value);
+      });
+
+    return service;
+  }
+
+  private addEnergyCharacteristics(service: Service): void {
+    const { Amperes, KilowattHours, VoltAmperes, Volts, Watts } =
+      this.platform.customCharacteristics;
+
+    const amperesCharacteristic = getOrAddCharacteristic(service, Amperes);
+    amperesCharacteristic.onGet(() => {
+      this.getRealtime().catch(this.logRejection.bind(this)); // this will eventually trigger update
+      return this.tplinkDevice.emeter.realtime.current ?? 0; // immediately returned cached value
+    });
+
+    const kilowattCharacteristic = getOrAddCharacteristic(
+      service,
+      KilowattHours
+    );
+    kilowattCharacteristic.onGet(() => {
+      this.getRealtime().catch(this.logRejection.bind(this)); // this will eventually trigger update
+      return this.tplinkDevice.emeter.realtime.total ?? 0; // immediately returned cached value
+    });
+
+    const voltAmperesCharacteristic = getOrAddCharacteristic(
+      service,
+      VoltAmperes
+    );
+    voltAmperesCharacteristic.onGet(() => {
+      this.getRealtime().catch(this.logRejection.bind(this)); // this will eventually trigger update
+      const { realtime } = this.tplinkDevice.emeter;
+      return (realtime.voltage ?? 0) * (realtime.voltage ?? 0); // immediately returned cached value
+    });
+
+    const voltsCharacteristic = getOrAddCharacteristic(service, Volts);
+    voltsCharacteristic.onGet(() => {
+      this.getRealtime().catch(this.logRejection.bind(this)); // this will eventually trigger update
+      return this.tplinkDevice.emeter.realtime.voltage ?? 0; // immediately returned cached value
+    });
+
+    const wattsCharacteristic = getOrAddCharacteristic(service, Watts);
+    wattsCharacteristic.onGet(() => {
+      this.getRealtime().catch(this.logRejection.bind(this)); // this will eventually trigger update
+      return this.tplinkDevice.emeter.realtime.power ?? 0; // immediately returned cached value
+    });
+
+    this.tplinkDevice.on('emeter-realtime-update', (emeterRealtime) => {
+      this.updateValue(
+        service,
+        amperesCharacteristic,
+        emeterRealtime.current ?? null
+      );
+      this.updateValue(
+        service,
+        kilowattCharacteristic,
+        emeterRealtime.total ?? null
+      );
+      this.updateValue(
+        service,
+        voltAmperesCharacteristic,
+        emeterRealtime.voltage != null && emeterRealtime.current != null
+          ? emeterRealtime.voltage * emeterRealtime.current
+          : null
+      );
+      this.updateValue(
+        service,
+        voltsCharacteristic,
+        emeterRealtime.voltage ?? null
+      );
+      this.updateValue(
+        service,
+        wattsCharacteristic,
+        emeterRealtime.power ?? null
+      );
+    });
+  }
+
+  private removeEnergyCharacteristics(service: Service) {
+    const { Amperes, KilowattHours, VoltAmperes, Volts, Watts } =
+      this.platform.customCharacteristics;
+
+    [Amperes, KilowattHours, VoltAmperes, Volts, Watts].forEach(
+      (characteristic) => {
+        this.removeCharacteristicIfExists(service, characteristic);
+      }
+    );
+  }
+
+  identify(): void {
+    this.log.info(`identify`);
+    this.tplinkDevice
+      .blink(1, 500)
+      .then(() => {
+        return this.tplinkDevice.blink(2, 500);
+      })
+      .then(() => {
+        this.log.debug(`identify done`);
+      })
+      .catch((reason) => {
+        this.log.error(`identify complete`);
+        this.log.error(reason);
+      });
+  }
+}

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -27,16 +27,16 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
       Categories.OUTLET
     );
 
-    this.getSysInfo = deferAndCombine((requestCount) => {
-      this.log.debug(`executing deferred getSysInfo count: ${requestCount}`);
-      return this.tplinkDevice.getSysInfo();
-    }, platform.config.waitTimeUpdate);
-
     this.tplinkDevice.sysInfo.children?.forEach((child, index) => {
       const outletService = this.addOutletService(child, index);
 
       this.configureOutletService(outletService, child);
     });
+
+    this.getSysInfo = deferAndCombine((requestCount) => {
+      this.log.debug(`executing deferred getSysInfo count: ${requestCount}`);
+      return this.tplinkDevice.getSysInfo();
+    }, platform.config.waitTimeUpdate);
 
     this.getRealtime = deferAndCombine((requestCount) => {
       this.log.debug(`executing deferred getRealtime count: ${requestCount}`);

--- a/src/homekit-device/powerstrip.ts
+++ b/src/homekit-device/powerstrip.ts
@@ -34,6 +34,8 @@ export default class HomeKitDevicePowerStrip extends HomekitDevice {
       service = this.configureOutletService(service, child, index);
     });
 
+    this.log.debug(`Device ID: ${this.tplinkDevice.id}`);
+
     this.getSysInfo = deferAndCombine((requestCount) => {
       this.log.debug(`executing deferred getSysInfo count: ${requestCount}`);
       return this.tplinkDevice.getSysInfo();

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -339,7 +339,10 @@ export default class TplinkSmarthomePlatform implements DynamicPlatformPlugin {
       return;
     }
 
-    if (this.homekitDevicesById.get(deviceId) !== undefined) {
+    const existingAccessory = this.homekitDevicesById.get(deviceId);
+    if (existingAccessory !== undefined) {
+      this.log.debug('Device already added: %s', existingAccessory.name);
+      existingAccessory.tplinkDevice.getSysInfo();
       return;
     }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -341,8 +341,6 @@ export default class TplinkSmarthomePlatform implements DynamicPlatformPlugin {
 
     const existingAccessory = this.homekitDevicesById.get(deviceId);
     if (existingAccessory !== undefined) {
-      this.log.debug('Device already added: %s', existingAccessory.name);
-      existingAccessory.tplinkDevice.getSysInfo();
       return;
     }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -339,8 +339,7 @@ export default class TplinkSmarthomePlatform implements DynamicPlatformPlugin {
       return;
     }
 
-    const existingAccessory = this.homekitDevicesById.get(deviceId);
-    if (existingAccessory !== undefined) {
+    if (this.homekitDevicesById.get(deviceId) !== undefined) {
       return;
     }
 


### PR DESCRIPTION
@plasticrake,
I have tried my hand at working with your API and your plugin for TPLink Smarthome for Homebridge and first and foremost, it was very well done, and I thank you for your work.

I have made several modifications here to implement sending Multi-Plug Devices to HomeKit as a Power Strip Single Grouped Accessory with the Outlets being individually controlled.

The way your API is written, it will allow for childId's to be used, but only when coming from a Plug Device, but sense the Plugs are all just services underneath a single device, I had to work with what I had.

There may be some changes that can be done on the API side of things to work with powerStrips and have them as a deviceType, but I didn't want to mess with the API.

The changes create a single homebridge and homekit accessory, they add multiple outlet services for each outlet and then allow for those outlets to be controlled individually either in the Kasa App, Homebridge, or HomeKit and the state will update across all areas.

I also looked into several of the open issues right now with the ECONNRESET issues and I found that changing over to UDP as the transport resolved those issues, not sure if that fixes the issue, but it stops the logs. I also removed the energy characteristics from default as they are listed under the HomeKit as optional and not required or used in HomeKit, they can still be enabled, but just disabled by default.

If you have any questions about this, please let me know.