### PR TITLE
fix: release deferred batch requests after each run

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,7 @@ export function deferAndCombine<T, U>(
   timeout: number,
   runNowFn?: (arg: U) => void
 ): (arg?: U) => Promise<T> {
-  const requests: {
+  let requests: {
     resolve: (value: T | PromiseLike<T>) => void;
     reject: (reason?: unknown) => void;
   }[] = [];
@@ -58,14 +58,17 @@ export function deferAndCombine<T, U>(
 
       setTimeout(() => {
         isWaiting = false;
-        fn(requests.length)
+        const pendingRequests = requests;
+        requests = [];
+
+        fn(pendingRequests.length)
           .then((value) => {
-            for (const d of requests) {
+            for (const d of pendingRequests) {
               d.resolve(value);
             }
           })
           .catch((error) => {
-            for (const d of requests) {
+            for (const d of pendingRequests) {
               d.reject(error);
             }
           });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -66,6 +66,32 @@ describe('utils', function () {
       },
       deferTime * 4
     );
+
+    it(
+      'should reset requestCount across batches',
+      async function () {
+        const requestCounts: number[] = [];
+        deferredFn = deferAndCombine((requestCount) => {
+          requestCounts.push(requestCount);
+          return Promise.resolve(requestCount);
+        }, deferTime);
+
+        const resultsOne = await Promise.all([
+          deferredFn(),
+          deferredFn(),
+          deferredFn(),
+        ]);
+
+        await delay(deferTime);
+
+        const resultsTwo = await Promise.all([deferredFn(), deferredFn()]);
+
+        expect(requestCounts).toEqual([3, 2]);
+        expect(resultsOne).toEqual([3, 3, 3]);
+        expect(resultsTwo).toEqual([2, 2]);
+      },
+      deferTime * 4
+    );
   });
 
   describe('lookup', function () {


### PR DESCRIPTION
## Summary
- fix a leak in `deferAndCombine()` by clearing the queued request resolver list after each deferred batch starts running
- keep batching behavior the same while making `requestCount` reflect only the current batch
- add a regression test proving separate batches no longer reuse the previous request queue

## Why
The deferred helper kept every prior batch's resolve/reject callbacks in the shared `requests` array for the lifetime of the device instance. That meant the queue grew over time and later batches saw cumulative `requestCount` values. Clearing the request queue once a batch has been captured releases those references and prevents the leak.

## Testing
- focused Jest run for `test/utils.spec.ts` using a temporary config override in this workspace because the repo test ignore pattern includes `/build/` and this checkout lives under `/Users/george/build/...`